### PR TITLE
feat: Docker build pipeline can be manually triggered

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,6 +8,14 @@ on:
   # Build release
   release:
     types: [published]
+  # Manual trigger
+  workflow_dispatch:
+    inputs:
+      connect_version:
+        description: "Connect binary version"
+        required: false
+        default: "0.8"
+        type: string
 
 jobs:
   build:
@@ -56,3 +64,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            CONNECT_CLIENT_VERSION=${{ inputs.connect_version || '0.8' }}

--- a/docker/studios.Dockerfile
+++ b/docker/studios.Dockerfile
@@ -1,5 +1,6 @@
 # Stage 1: Get the Seqera Connect client
-FROM public.cr.seqera.io/platform/connect-client:0.8 AS connect
+ARG CONNECT_CLIENT_VERSION=0.8
+FROM public.cr.seqera.io/platform/connect-client:${CONNECT_CLIENT_VERSION} AS connect
 
 # Final image: Start from the official node-red image
 FROM nodered/node-red:latest-debian


### PR DESCRIPTION
The Studios container needed to be rebuilt to pick up the latest changes, so I added a manual trigger for the GitHub Actions workflow and made the Connect client version a build argument.
