### PR TITLE
feat: update datasets node to support header line

### DIFF
--- a/nodes/dataset-create.html
+++ b/nodes/dataset-create.html
@@ -30,6 +30,10 @@
       <option value="tsv">TSV</option>
     </select>
   </div>
+  <div class="form-row">
+    <label for="node-input-hasHeader"><i class="fa fa-table"></i> Has header</label>
+    <input type="checkbox" id="node-input-hasHeader" style="display: inline-block; width: auto; vertical-align: top;" />
+  </div>
 </script>
 
 <!-- prettier-ignore -->
@@ -41,6 +45,7 @@ Creates a new dataset and uploads its file contents to Seqera Platform.
 : datasetName (string) : Name of the dataset to create.
 : fileContents (string | buffer) : CSV/TSV string or buffer to upload. Defaults to `msg.payload`.
 : fileType (string) : File format / MIME type. Choose between 'csv' (default) or 'tsv'.
+: hasHeader (boolean) : Whether the file has a header row. When enabled, adds `header=true` query parameter to the upload API call.
 : description (string) : Optional description for the dataset.
 : workspaceId (string) : Override the workspace ID from the config node.
 
@@ -89,6 +94,7 @@ by Seqera Platform to validate the file contents.
       description: { value: "" },
       descriptionType: { value: "str" },
       fileType: { value: "csv" },
+      hasHeader: { value: false },
     },
     oneditprepare: function () {
       function ti(id, val, type, def = "str") {
@@ -106,6 +112,7 @@ by Seqera Platform to validate the file contents.
       ti("#node-input-description", this.description || "", this.descriptionType || "str");
       ti("#node-input-workspaceId", this.workspaceId || "", this.workspaceIdType || "str");
       $("#node-input-fileType").val(this.fileType || "csv");
+      $("#node-input-hasHeader").prop("checked", this.hasHeader || false);
     },
     oneditsave: function () {
       function save(id, prop, propType) {
@@ -117,6 +124,7 @@ by Seqera Platform to validate the file contents.
       save.call(this, "#node-input-description", "description", "descriptionType");
       save.call(this, "#node-input-workspaceId", "workspaceId", "workspaceIdType");
       this.fileType = $("#node-input-fileType").val();
+      this.hasHeader = $("#node-input-hasHeader").prop("checked");
     },
   });
 </script>

--- a/nodes/dataset-create.js
+++ b/nodes/dataset-create.js
@@ -9,6 +9,7 @@ module.exports = function (RED) {
     node.fileContentsProp = config.fileContents;
     node.fileContentsPropType = config.fileContentsType;
     node.fileType = config.fileType || "csv";
+    node.hasHeader = config.hasHeader;
     node.descriptionProp = config.description;
     node.descriptionPropType = config.descriptionType;
     node.baseUrlProp = config.baseUrl;
@@ -105,7 +106,10 @@ module.exports = function (RED) {
         node.status({ fill: "yellow", shape: "ring", text: `uploading: ${formatDateTime()}` });
 
         let uploadUrl = `${baseUrl.replace(/\/$/, "")}/datasets/${datasetId}/upload`;
-        if (workspaceId != null) uploadUrl += `?workspaceId=${workspaceId}`;
+        const queryParams = [];
+        if (workspaceId != null) queryParams.push(`workspaceId=${workspaceId}`);
+        if (node.hasHeader) queryParams.push(`header=true`);
+        if (queryParams.length > 0) uploadUrl += `?${queryParams.join("&")}`;
 
         const form = new FormData();
         const buffer = Buffer.isBuffer(fileContents)
@@ -151,6 +155,7 @@ module.exports = function (RED) {
       token: { value: "token" },
       tokenType: { value: "str" },
       fileType: { value: "csv" },
+      hasHeader: { value: false },
     },
   });
 };


### PR DESCRIPTION
Adds a new `hasHeader` configuration option to the `seqera-dataset-create` node that allows users to specify when their dataset files contain a header row.

### Changes

- Added **hasHeader** checkbox to the node configuration UI. When enabled, appends `header=true` query parameter to the dataset upload API call

When hasHeader is checked, the upload URL becomes:
```
/datasets/{id}/upload?header=true
```
