### PR TITLE
Add customizable run name field to workflow launch node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- Added customizable run name field to workflow launch node. Users can now specify a custom name for workflow runs, which will override the default auto-generated name. If left blank, Seqera Platform will generate a default name automatically.
+
 ## [1.0.1] - 2025-06-18
 
 - Use two separate Docker image names for the vanilla and Studios images.

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Launch a new workflow (pipeline run) on Seqera Platform.
 
 - **launchpadName**: Name of a Launchpad entry. If supplied the node will look up the pipeline, fetch its default launch configuration and submit the run.
 - **params**: Key/value pairs to merge into `paramsText`. By default these are read from `msg.params` but this property can be changed in the node.
+- **runName**: Custom name for the workflow run. Optional - if left blank, Seqera Platform will generate a default name automatically.
 - **body**: A fully-formed request body placed on `msg.body` or `msg.payload`. If present it is sent as-is and the `launchpadName` lookup is skipped.
 - **workspaceId**: Override the workspace ID from the Config node.
 - **sourceWorkspaceId**: Workspace that owns the source pipeline when launching a shared workflow.

--- a/nodes/workflow-launch.html
+++ b/nodes/workflow-launch.html
@@ -12,6 +12,10 @@
     <input type="text" id="node-input-paramsKey" />
   </div>
   <div class="form-row">
+    <label for="node-input-runName"><i class="fa fa-play-circle"></i> Run name</label>
+    <input type="text" id="node-input-runName" />
+  </div>
+  <div class="form-row">
     <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
     <input type="text" id="node-input-name" />
   </div>
@@ -33,6 +37,7 @@ Launches a workflow using the Seqera Platform API.
 
 : launchpadName (string) : The human-readable name of a pipeline in the launchpad to use.
 : params (object) : JSON object containing parameters to merge with the launchpad's default parameters.
+: runName (string) : Custom name for the workflow run (optional, defaults to auto-generated name).
 : workspaceId (string) : Override the workspace ID from the config node.
 : sourceWorkspaceId (string) : The source workspace ID (if a shared workflow and different to workspaceId).
 : body (object) : A full launch request body (alternative to using launchpadName).
@@ -76,6 +81,8 @@ Workflow parameters can be provided as a JSON object and will be merged with the
       launchpadNameType: { value: "str" },
       paramsKey: { value: "{}" },
       paramsKeyType: { value: "json" },
+      runName: { value: "" },
+      runNameType: { value: "str" },
       workspaceId: { value: "" },
       workspaceIdType: { value: "str" },
       sourceWorkspaceId: { value: "" },
@@ -97,6 +104,7 @@ Workflow parameters can be provided as a JSON object and will be merged with the
       $("#node-input-paramsKey").typedInput("type", this.paramsKeyType || "json");
 
       ti("#node-input-launchpadName", this.launchpadName || "", this.launchpadNameType || "str");
+      ti("#node-input-runName", this.runName || "", this.runNameType || "str");
       ti("#node-input-workspaceId", this.workspaceId || "", this.workspaceIdType || "str");
       ti("#node-input-sourceWorkspaceId", this.sourceWorkspaceId || "", this.sourceWorkspaceIdType || "str");
 
@@ -199,6 +207,7 @@ Workflow parameters can be provided as a JSON object and will be merged with the
       }
       save.call(this, "#node-input-launchpadName", "launchpadName", "launchpadNameType");
       save.call(this, "#node-input-paramsKey", "paramsKey", "paramsKeyType");
+      save.call(this, "#node-input-runName", "runName", "runNameType");
       save.call(this, "#node-input-workspaceId", "workspaceId", "workspaceIdType");
       save.call(this, "#node-input-sourceWorkspaceId", "sourceWorkspaceId", "sourceWorkspaceIdType");
     },

--- a/nodes/workflow-launch.js
+++ b/nodes/workflow-launch.js
@@ -86,6 +86,8 @@ module.exports = function (RED) {
     node.launchpadNamePropType = config.launchpadNameType;
     node.paramsProp = config.paramsKey;
     node.paramsPropType = config.paramsKeyType;
+    node.runNameProp = config.runName;
+    node.runNamePropType = config.runNameType;
     node.baseUrlProp = config.baseUrl;
     node.baseUrlPropType = config.baseUrlType;
     node.workspaceIdProp = config.workspaceId;
@@ -127,6 +129,7 @@ module.exports = function (RED) {
 
       const launchpadName = await evalProp(node.launchpadNameProp, node.launchpadNamePropType);
       const paramsObj = await evalProp(node.paramsProp, node.paramsPropType);
+      const runName = await evalProp(node.runNameProp, node.runNamePropType);
       const baseUrlOverride = await evalProp(node.baseUrlProp, node.baseUrlPropType);
       const workspaceIdOverride = await evalProp(node.workspaceIdProp, node.workspaceIdPropType);
       const sourceWorkspaceIdOverride = await evalProp(node.sourceWorkspaceIdProp, node.sourceWorkspaceIdPropType);
@@ -188,6 +191,12 @@ module.exports = function (RED) {
           } catch (_) {}
         }
         body.launch.paramsText = JSON.stringify({ ...existingParams, ...paramsObj });
+      }
+
+      // Set custom run name if provided
+      if (runName && runName.trim()) {
+        body.launch = body.launch || {};
+        body.launch.runName = runName.trim();
       }
 
       // Build URL with query params


### PR DESCRIPTION
## Summary

This PR adds a customizable run name field to the workflow launch node, allowing users to specify custom names for their workflow runs.

## Changes

- **UI**: Added new "Run name" input field in workflow-launch.html
- **Runtime**: Added logic to set runName in the launch request body when provided
- **Documentation**: Updated README.md with the new field
- **Help text**: Updated inline node documentation
- **CHANGELOG**: Documented the new feature

## Features

The run name field:
- **Optional**: Can be left blank for auto-generated names from Seqera Platform
- **Flexible**: Supports dynamic values from message properties, flow/global context, environment variables, and JSONata expressions
- **Clean**: Automatically trims whitespace
- **Integrated**: Uses the existing TypedInput system for consistency

## Testing

The implementation follows existing patterns in the codebase and integrates seamlessly with the workflow launch node's architecture.

## Related

Resolves user request to customize run names when launching pipelines.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)