### PR TITLE
Standardise `..msg` spread, update retry example.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,36 @@ const evalProp = async (p, t, msg) => {
 
 Always evaluate properties inside the `node.on("input", ...)` handler so they reflect current message context.
 
+### Message Property Passthrough
+
+**All nodes preserve unrecognized input message properties in their output.**
+
+This is implemented using the spread operator pattern:
+
+```javascript
+const outputMsg = {
+  ...msg, // Spreads all input properties first
+  payload: response.data, // Then overwrites specific properties
+  workflowId: workflowId,
+  // etc.
+};
+send(outputMsg);
+```
+
+**Key behaviors:**
+
+- Any custom properties on the input `msg` object (e.g., `msg._context`, `msg.customId`, `msg.correlationId`) are automatically copied to the output
+- Node-specific properties (like `payload`, `workflowId`, `datasetId`, `studioId`) are set/overwritten as documented
+- This enables flow-wide context tracking and message correlation without modifying node code
+- Works for all node types including monitor nodes with multiple outputs (all outputs receive the same passthrough properties)
+
+**Common use cases:**
+
+- `msg._context` - Preserve context across multiple nodes in a flow
+- `msg.correlationId` - Track messages across parallel branches
+- `msg.userId` - Maintain user session information through workflow
+- Any custom metadata needed for flow logic or debugging
+
 ### Node Types
 
 **[workflow-launch.js](nodes/workflow-launch.js):**

--- a/README.md
+++ b/README.md
@@ -98,6 +98,52 @@ See the [example docs](./docs/README.md) for more information.
 
 # Usage
 
+## Message Property Passthrough
+
+**All Seqera nodes automatically preserve unrecognized message properties from input to output.**
+
+This means that any custom properties you add to the input message (such as `msg._context`, `msg.correlationId`, `msg.customMetadata`, etc.) will be copied through to the output message alongside the node's standard properties.
+
+### How it works
+
+Each node uses the JavaScript spread operator to copy all input properties before adding node-specific outputs:
+
+```javascript
+const outputMsg = {
+  ...msg,              // All input properties preserved
+  payload: ...,        // Node-specific properties added/overwritten
+  workflowId: ...,
+};
+```
+
+### Common use cases
+
+- **`msg._context`** - Preserve shared context across multiple nodes in a flow
+- **`msg.correlationId`** - Track messages through parallel branches or complex flows
+- **`msg.userId`** - Maintain user session information throughout a workflow
+- **Custom metadata** - Any debugging, logging, or business logic data
+
+### Example
+
+```javascript
+// Input message
+{
+  _context: { requestId: "abc123", source: "webhook" },
+  correlationId: "order-789",
+  payload: { ... }
+}
+
+// After passing through a workflow-launch node, output includes:
+{
+  _context: { requestId: "abc123", source: "webhook" },  // Preserved
+  correlationId: "order-789",                            // Preserved
+  payload: { ... },                                      // Overwritten with API response
+  workflowId: "xyz456"                                   // Added by node
+}
+```
+
+This works for **all node types**, including monitor nodes with multiple outputs (all outputs receive the same passthrough properties).
+
 ## Seqera Config Node
 
 Create a Seqera Config node to store your API credentials and default settings.

--- a/examples/05 - Auto-resume on workflow failure.json
+++ b/examples/05 - Auto-resume on workflow failure.json
@@ -65,8 +65,8 @@
     "poll": "15",
     "pollUnits": "seconds",
     "x": 570,
-    "y": 160,
-    "wires": [[], ["debug_success"], ["launch_node"]]
+    "y": 180,
+    "wires": [[], ["debug_success"], ["73841c107d946dcc"]]
   },
   {
     "id": "debug_success",
@@ -77,42 +77,42 @@
     "tosidebar": true,
     "console": false,
     "tostatus": false,
-    "complete": "payload",
-    "targetType": "msg",
+    "complete": "true",
+    "targetType": "full",
     "statusVal": "",
     "statusType": "auto",
-    "x": 780,
-    "y": 160,
+    "x": 770,
+    "y": 180,
     "wires": []
   },
   {
     "id": "comment_trigger",
     "type": "comment",
     "z": "resume_example_tab",
-    "name": "1. Trigger",
+    "name": "Trigger",
     "info": "Click this inject node to start the workflow.\n\nIn a real automation, you might trigger this\nfrom a file upload, scheduled time, or other event.\n\nThe initial message has no workflow ID,\nso the launch node will start fresh.",
-    "x": 140,
-    "y": 100,
+    "x": 130,
+    "y": 120,
     "wires": []
   },
   {
     "id": "comment_launch",
     "type": "comment",
     "z": "resume_example_tab",
-    "name": "2. Launch (with loop)",
+    "name": "Launch (with loop)",
     "info": "This node handles BOTH initial launch AND resume.\n\n**Configuration:**\n- Resume from: `msg.workflowId` (type: msg)\n\n**First run:** `msg.workflowId` is `undefined` → launches fresh\n**Loop back:** `msg.workflowId` is populated → fetches session ID and resumes\n\nThe same node works for both cases! When a workflow ID is provided,\nthe node automatically fetches the session ID from the API and enables resume.",
     "x": 350,
-    "y": 100,
+    "y": 120,
     "wires": []
   },
   {
     "id": "comment_monitor",
     "type": "comment",
     "z": "resume_example_tab",
-    "name": "3. Monitor",
-    "info": "Monitors the workflow status.\n\n**Three outputs:**\n1. Running status (not connected - no action needed)\n2. Success (workflow completed) → Flow ends here with debug output\n3. Failed (workflow errored) → Loops directly back to Launch node\n\nOutput 3 connects directly back to the launch node, creating the resume loop.",
-    "x": 560,
-    "y": 100,
+    "name": "Monitor",
+    "info": "Monitors the workflow status.\n\n**Three outputs:**\n1. Running status (not connected - no action needed)\n2. Success (workflow completed) → Flow ends here with debug output\n3. Failed (workflow errored) → Loops directly back to Launch node\n\nOutput 3 connects back to the launch node, creating the resume loop.",
+    "x": 550,
+    "y": 120,
     "wires": []
   },
   {
@@ -120,24 +120,107 @@
     "type": "comment",
     "z": "resume_example_tab",
     "name": "Outputs",
-    "info": "**Success** - Final successful completion (debug output)\n\nThe loop continues until:\n- Workflow succeeds (output 2)\n- Manual intervention stops the flow",
+    "info": "**Success** - Final successful completion (debug output)",
     "x": 770,
-    "y": 100,
+    "y": 120,
     "wires": []
   },
   {
-    "id": "59ebff648cf0649e",
-    "type": "comment",
+    "id": "73841c107d946dcc",
+    "type": "change",
     "z": "resume_example_tab",
-    "name": "Warning! ⚠️",
-    "info": "Please note: this flow will loop _forever_.\nOr at least, until the workflow succeeds.\n\n**You don't want this in practice**.\nIf there is some problem which means the workflow\nwill never succeed, ie. it keeps failing for the same\nreason, it'll just go on and on and on.\n\nYou'll want some custom logic in this loop to\nadd some safeguards.",
-    "x": 470,
-    "y": 240,
-    "wires": [],
-    "icon": "font-awesome/fa-warning"
+    "name": "Increment retry counter",
+    "rules": [
+      {
+        "t": "set",
+        "p": "_retries",
+        "pt": "msg",
+        "to": "_retries ? _retries + 1 : 1",
+        "tot": "jsonata"
+      }
+    ],
+    "action": "",
+    "property": "",
+    "from": "",
+    "to": "",
+    "reg": false,
+    "x": 190,
+    "y": 280,
+    "wires": [["d462ab97a42a95e0"]]
   },
   {
-    "id": "ce068971d6f3f1f0",
+    "id": "d462ab97a42a95e0",
+    "type": "switch",
+    "z": "resume_example_tab",
+    "name": "<= 3 retries?",
+    "property": "_retries",
+    "propertyType": "msg",
+    "rules": [
+      {
+        "t": "lte",
+        "v": "3",
+        "vt": "str"
+      },
+      {
+        "t": "else"
+      }
+    ],
+    "checkall": "true",
+    "repair": false,
+    "outputs": 2,
+    "x": 410,
+    "y": 280,
+    "wires": [["launch_node"], ["59af93d472724fe5"]]
+  },
+  {
+    "id": "59af93d472724fe5",
+    "type": "debug",
+    "z": "resume_example_tab",
+    "name": "✘ Give up",
+    "active": true,
+    "tosidebar": true,
+    "console": false,
+    "tostatus": false,
+    "complete": "true",
+    "targetType": "full",
+    "statusVal": "",
+    "statusType": "auto",
+    "x": 590,
+    "y": 280,
+    "wires": []
+  },
+  {
+    "id": "3f8061dd9c9fca4c",
+    "type": "comment",
+    "z": "resume_example_tab",
+    "name": "Counter",
+    "info": "This `change` node sets `msg._retries` if\nnot already set, and increments it by\none if it does.\n\nSeqera Node-RED nodes pass through\nunrecognised `msg` variables, so this\npersists through the loop for each launch.\n\nMultiple pipeline launches can be triggered\nin parallel and each will have its own\nretry counter in the `msg` object.",
+    "x": 150,
+    "y": 320,
+    "wires": []
+  },
+  {
+    "id": "5ee40e98b81ff1e7",
+    "type": "comment",
+    "z": "resume_example_tab",
+    "name": "Switch",
+    "info": "A Node-RED `switch` node checks if we have\nhad 3 retries already by inspecting our\n`msg._retries` counter.",
+    "x": 390,
+    "y": 320,
+    "wires": []
+  },
+  {
+    "id": "9d80d663bb701bf6",
+    "type": "comment",
+    "z": "resume_example_tab",
+    "name": "Failure",
+    "info": "**Failure** - Give up after 3 attempts (debug output)",
+    "x": 590,
+    "y": 320,
+    "wires": []
+  },
+  {
+    "id": "ec31addc40995619",
     "type": "global-config",
     "env": [],
     "modules": {

--- a/nodes/datalink-list.js
+++ b/nodes/datalink-list.js
@@ -49,15 +49,18 @@ module.exports = function (RED) {
 
       try {
         const result = await datalinkUtils.listDataLink(RED, node, msg);
-        msg.payload = {
-          files: result.items,
-          resourceType: result.resourceType,
-          resourceRef: result.resourceRef,
-          provider: result.provider,
+        const outMsg = {
+          ...msg,
+          payload: {
+            files: result.items,
+            resourceType: result.resourceType,
+            resourceRef: result.resourceRef,
+            provider: result.provider,
+          },
+          files: result.files.map((it) => `${result.resourceRef}/${it}`),
         };
-        msg.files = result.files.map((it) => `${result.resourceRef}/${it}`);
         node.status({ fill: "green", shape: "dot", text: `${result.items.length} items: ${formatDateTime()}` });
-        send(msg);
+        send(outMsg);
         if (done) done();
       } catch (err) {
         node.error(`Seqera datalink list failed: ${err.message}`, msg);

--- a/nodes/dataset-create.js
+++ b/nodes/dataset-create.js
@@ -122,10 +122,13 @@ module.exports = function (RED) {
         const uploadHeaders = form.getHeaders();
         const uploadResp = await apiCall(node, "post", uploadUrl, { headers: uploadHeaders, data: form });
 
-        msg.payload = uploadResp.data;
-        msg.datasetId = datasetId;
+        const outMsg = {
+          ...msg,
+          payload: uploadResp.data,
+          datasetId: datasetId,
+        };
         node.status({ fill: "green", shape: "dot", text: `uploaded: ${formatDateTime()}` });
-        send(msg);
+        send(outMsg);
         if (done) done();
       } catch (err) {
         if (!err.api_call)

--- a/nodes/studios-create.js
+++ b/nodes/studios-create.js
@@ -165,10 +165,13 @@ module.exports = function (RED) {
         if (qs.toString()) url += `?${qs.toString()}`;
 
         const resp = await apiCall(node, "post", url, { headers: { "Content-Type": "application/json" }, data: body });
-        msg.payload = resp.data;
-        msg.studioId = resp.data?.studio?.sessionId || resp.data?.sessionId;
+        const outMsg = {
+          ...msg,
+          payload: resp.data,
+          studioId: resp.data?.studio?.sessionId || resp.data?.sessionId,
+        };
         node.status({ fill: "green", shape: "dot", text: `created: ${formatDateTime()}` });
-        send(msg);
+        send(outMsg);
         if (done) done();
       } catch (err) {
         node.status({ fill: "red", shape: "ring", text: `error: ${formatDateTime()}` });

--- a/nodes/workflow-launch.js
+++ b/nodes/workflow-launch.js
@@ -304,10 +304,13 @@ module.exports = function (RED) {
 
       try {
         const response = await apiCall(node, "post", url, { headers, data: body });
-        msg.payload = response.data;
-        msg.workflowId = response.data?.workflowId || response.data?.workflow?.id;
+        const outMsg = {
+          ...msg,
+          payload: response.data,
+          workflowId: response.data?.workflowId || response.data?.workflow?.id,
+        };
         node.status({ fill: "green", shape: "dot", text: `launched: ${formatDateTime()}` });
-        send(msg);
+        send(outMsg);
         if (done) done();
       } catch (err) {
         node.error(`Seqera API request failed: ${err.message}\nRequest: POST ${url}`, msg);


### PR DESCRIPTION
Ok, turned out that some - not all - of the Seqera nodes were already passing through unrecognised `msg` variables. Updated the ones that weren't so that it's standard for all.

Now any custom `msg` variables can be used.

Updated the retry example to set a custom `msg._retries` variable on failure and increment it if found. We now have a super simple check and bail after 3 attempts! No custom JS function nodes required 🎉

<img width="1764" height="620" alt="CleanShot 2025-11-05 at 00 17 34@2x" src="https://github.com/user-attachments/assets/281c48e1-b1c9-4b6c-ab9a-b2f2956419a8" />
