### PR TITLE
ci: switch from pre-commit to prek NOTASK

### DIFF
--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -11,8 +11,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - uses: pre-commit/action@v3.0.1
+      - uses: j178/prek-action@0bb87d7f00b0c99306c8bcb8b8beba1eb581c037 # v1.1.1


### PR DESCRIPTION
## Summary
- Replace `pre-commit/action` with `j178/prek-action`, a fast Rust-based drop-in replacement
- Remove the `actions/setup-python` step since prek doesn't need Python
- Resolves the issue where `pre-commit/action` internally uses `actions/cache@v4` as a tag reference instead of a SHA-pinned commit, violating org policy

Reference: https://github.com/seqeralabs/fusion/pull/1280

## Test plan
- [ ] Verify the pre-commit workflow passes on this PR
- [ ] Confirm prek runs the same hooks from `.pre-commit-config.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
